### PR TITLE
Don't ignore global ssh_config by default.

### DIFF
--- a/ssh-ident
+++ b/ssh-ident
@@ -524,7 +524,6 @@ def FindSSHConfig(identity, config):
     string, the configuration file to use
   """
   directories = [os.path.join(config.Get("DIR_IDENTITIES"), identity)]
-  directories.append(os.path.expanduser("~/.ssh"))
 
   pattern = re.compile(config.Get("PATTERN_CONFIG"))
   sshconfigs = collections.defaultdict(dict)


### PR DESCRIPTION
Specifying a config file to ssh makes it impossible to also read the global
config. Which is daft, but that's what ssh does. So I've removed ~/.ssh as
a place to look for configs, on the principle that not specifying any
config will read both the global ssh_config and ~/.ssh/config, and that's
the expected default behaviour.

Any identity specific config will still ignore the global config, but that
seems fine to me.