### PR TITLE
Replace deprecated distutils usage with shutil.which(). Fixes Issue #65

### DIFF
--- a/ssh-ident
+++ b/ssh-ident
@@ -313,7 +313,7 @@ CREDITS
 from __future__ import print_function
 
 import collections
-import distutils.spawn
+import shutil
 import errno
 import fcntl
 import getpass
@@ -928,10 +928,10 @@ def AutodetectBinary(argv, config):
       p for p in normalized_path if p != ssh_ident_path])
 
   # Find an executable with the desired name.
-  binary_path = distutils.spawn.find_executable(binary_name, search_path)
+  binary_path = shutil.which(binary_name, path=search_path)
   if not binary_path:
     # Nothing found. Try to find something named 'ssh'.
-    binary_path = distutils.spawn.find_executable('ssh')
+    binary_path = shutil.which('ssh')
 
   if binary_path:
     config.Set("BINARY_SSH", binary_path)
@@ -997,9 +997,9 @@ def main(argv):
   # which is not always the case. argv[0] may also just have the binary
   # name if found in a path.
   binary_path = os.path.realpath(
-    distutils.spawn.find_executable(config.Get("BINARY_SSH")))
+    shutil.which(config.Get("BINARY_SSH")))
   ssh_ident_path = os.path.realpath(
-    distutils.spawn.find_executable(argv[0]))
+    shutil.which(argv[0]))
   if binary_path == ssh_ident_path:
     message = textwrap.dedent("""\
     ssh-ident found '{0}' as the next command to run.


### PR DESCRIPTION
Replace all distutils.spawn.find_executable() calls by shutil.which() as suggested in PEP632.